### PR TITLE
Fix: Implement SPA redirect for GitHub Pages

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Redirecting...</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script takes the current url and converts the path and query
+      // string into just a query string, and then redirects the browser
+      // to the new url with only a query string and hash fragment,
+      // e.g. https://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+      // https://www.foo.tld/?/one/two&a=b~and~c=d#qwe
+      // Note: this 404.html file must be at least 512 bytes for it to work
+      // with Internet Explorer (it is currently > 512 bytes)
+
+      // If you're creating a Project GitHub Page, change this
+      // value to true.
+      var segmentCount = 1; // Set to 1 if deploying to <username>.github.io/<project-name>
+
+      var l = window.location;
+      l.replace(
+        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+        l.pathname.split('/').slice(0, 1 + segmentCount).join('/') + '/?/' +
+        l.pathname.slice(1).split('/').slice(segmentCount).join('/').replace(/&/g, '~and~') +
+        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+        l.hash
+      );
+
+    </script>
+  </head>
+  <body>
+  </body>
+</html>


### PR DESCRIPTION
Adds a 404.html file to handle client-side routing for single-page applications deployed to GitHub Pages.

When you refresh or directly access a non-root URL, GitHub Pages would typically return a 404 error. This new 404.html file contains a script that captures the intended path and redirects you to the root index.html, appending the path information in a way that the client-side router (e.g., React Router) can interpret and display the correct view.

The script in 404.html is configured with `segmentCount = 1`, which is appropriate for project pages hosted in a subdirectory (e.g., <username>.github.io/<repository-name>).

The existing Vite configuration (with `base: '/convoice'`) and the GitHub Actions deployment workflow are expected to work correctly with this change, ensuring the 404.html is placed at the root of the deployed site.