### PR TITLE
Fix: Print preview window now closes automatically

### DIFF
--- a/src/presentation/react/components/Header.jsx
+++ b/src/presentation/react/components/Header.jsx
@@ -34,7 +34,7 @@ const Header = ({
         // Delay printing slightly to ensure content is rendered, especially complex CSS or images
         setTimeout(() => {
             printWindow.print();
-            // Not auto-closing: printWindow.close();
+            printWindow.close(); // Now auto-closing
         }, 250);
     } else {
         if (window.toast && typeof window.toast.error === 'function') {


### PR DESCRIPTION
The print preview window was not closing after you printed or canceled the print dialog. This was because the line responsible for closing the window (`printWindow.close();`) was commented out in `src/presentation/react/components/Header.jsx`.

This commit uncomments the `printWindow.close();` line in the `handlePrintEvents` function, ensuring that the preview window is closed after the print dialog interaction is complete.