### PR TITLE
Fix: Ensures print preview can be reopened after cancellation

### DIFF
--- a/src/presentation/react/components/Header.jsx
+++ b/src/presentation/react/components/Header.jsx
@@ -26,7 +26,7 @@ const Header = ({
         return;
     }
     const printableHtml = generatePrintableEventsHtml(filteredEvents);
-    const printWindow = window.open('', '_blank', 'height=800,width=600');
+    const printWindow = window.open('', 'printWindow_' + Date.now(), 'height=800,width=600');
     if (printWindow) {
         printWindow.document.open();
         printWindow.document.write(printableHtml);


### PR DESCRIPTION
This commit addresses an issue where the print preview modal would not reappear if you had previously cancelled a print operation.

The fix involves modifying the `handlePrintEvents` function in `src/presentation/react/components/Header.jsx` to use a unique window name for each print attempt (e.g., 'printWindow_' + Date.now()). This prevents potential conflicts or browser issues with reusing the '_blank' target name too quickly after a programmatically closed window, ensuring that `window.open()` reliably creates a new print preview window on each click of the print button.

The previous fix (uncommenting `printWindow.close()`) is retained to ensure the window closes after printing or cancellation.